### PR TITLE
Fix Tygent node display category

### DIFF
--- a/packages/nodes-base/nodes/Tygent/Tygent.node.json
+++ b/packages/nodes-base/nodes/Tygent/Tygent.node.json
@@ -5,5 +5,8 @@
 	"categories": ["AI"],
 	"resources": {
 		"primaryDocumentation": [{ "url": "https://github.com/tygent-ai/tygent-js" }]
+	},
+	"subcategories": {
+		"AI": ["Miscellaneous"]
 	}
 }


### PR DESCRIPTION
## Summary
- ensure the Tygent node is assigned to the Miscellaneous AI subcategory

## Testing
- `pnpm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_687854da26688327bb6120e798d9d9cb