### PR TITLE
Fix tygent-js module resolution

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -12,7 +12,8 @@
 			"@/*": ["./*"],
 			"@test/*": ["../test/shared/*"],
 			"@test-integration/*": ["../test/integration/shared/*"],
-			"tygent-js": ["../tygent-js"]
+			"tygent-js": ["../../tygent-js"],
+			"tygent-js/*": ["../../tygent-js/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		// TODO: remove all options below this line

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,7 +11,8 @@
 		"paths": {
 			"@/*": ["./*"],
 			"@test/*": ["../test/shared/*"],
-			"@test-integration/*": ["../test/integration/shared/*"]
+			"@test-integration/*": ["../test/integration/shared/*"],
+			"tygent-js": ["../tygent-js"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		// TODO: remove all options below this line


### PR DESCRIPTION
## Summary
- update CLI tsconfig path mapping so TypeScript can resolve `tygent-js`

## Testing
- `npx tsc -p packages/cli/tsconfig.build.json` *(fails: cannot find module '@n8n/db', etc., but no tygent-js errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a39a236588327a119b7de41274fd3