### PR TITLE
Fix body injection for non-validated requests

### DIFF
--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -72,6 +72,8 @@ export class ControllerRegistry {
 							else {
 								return res.status(400).json(output.error.errors[0]);
 							}
+						} else {
+							args.push(req[arg.type]);
 						}
 					} else throw new UnexpectedError('Unknown arg type: ' + arg.type);
 				}


### PR DESCRIPTION
## Summary
- push raw body or query data when controller arg lacks DTO validation

## Testing
- `pnpm --filter ./packages/cli test` *(fails: Cannot find module '@n8n/backend-common')*
- `npx jest packages/cli/test/integration/tygent.service.test.ts` *(fails to resolve module path)*

------
https://chatgpt.com/codex/tasks/task_e_687af0043df48327ad7a866aa45e10de